### PR TITLE
Feat/wizard mcp presenter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,14 @@ pip install -e .
 actcli doctor
 ```
 
+**Interactive UI (VSCode-style interface):**
+```bash
+actcli                        # Default VSCode-style interface
+ACTCLI_LAYOUT=vscode actcli   # Explicit VSCode layout
+ACTCLI_LAYOUT=claude actcli   # Claude CLI-style layout
+ACTCLI_LAYOUT=basic actcli    # Basic terminal layout
+```
+
 **Linting and formatting (from AGENTS.md):**
 ```bash
 ruff check src tests
@@ -47,6 +55,10 @@ ActCLI is a terminal-native toolkit for actuarial workflows with multi-model "ro
 **Core Structure:**
 - `src/actcli/cli.py` - Main Typer-based CLI entry point
 - `src/actcli/commands/` - Individual command implementations (chat, doctor, auth, models, pr)
+- `src/actcli/ui/` - Terminal user interface implementations
+  - `vscode_layout.py` - VSCode-style interface with sidebar and themes
+  - `claude_layout.py` - Claude CLI-inspired minimal layout
+  - `enhanced_layout.py` - Advanced UI examples and components
 - `src/actcli/seminar/` - Multi-model coordination system
   - `coordinator.py` - Orchestrates concurrent model responses
   - `synthesizer.py` - Combines multi-round discussions
@@ -60,6 +72,9 @@ ActCLI is a terminal-native toolkit for actuarial workflows with multi-model "ro
 - Local model storage under `./models` directory for project isolation
 - Rich console output with `--no-color` support throughout
 - Environment variable `ACTCLI_MODE` controls hybrid vs offline behavior
+- **UI System**: `prompt_toolkit` Application framework for full-screen terminal control
+- **Layout Selection**: Environment variable `ACTCLI_LAYOUT` (vscode/claude/basic)
+- **Theme Support**: Dynamic color schemes (dark/light/nord) with real-time switching
 
 **Multi-Model Chat Flow:**
 1. Parse comma-separated provider list (e.g., "llama3,claude,gpt")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,29 @@
 # ActCLI (prototype)
 
-ActCLI is a terminal‑native toolkit for actuarial workflows with a multi‑model "roundtable" chat. This scaffold demonstrates the WOW path: concurrent responses from multiple models, a second round that references peers, and a simple synthesis. It also includes a first‑run doctor and stubbed auth.
+ActCLI is a terminal‑native toolkit for actuarial workflows with a multi‑model "roundtable" chat featuring a **VSCode-style interface**. This scaffold demonstrates the WOW path: concurrent responses from multiple models, a second round that references peers, and a simple synthesis. It also includes a first‑run doctor and stubbed auth.
+
+## 🎨 User Interface
+
+ActCLI features a professional **VSCode-style terminal interface** with:
+
+- **Left Sidebar (25%)**: Expandable sections for models, themes, MCP servers, locations
+- **ASCII Art Logo**: "ActCLI - Actuarial CLI"
+- **Right Chat Area (75%)**: Conversation history and input
+- **Theme Switching**: Dark, Light, Nord themes (Ctrl+T)
+- **Model Management**: See available vs active models in roundtable
+- **Keyboard Navigation**: Arrow keys, text selection, copy functionality
+
+Start the interactive interface with:
+```bash
+actcli  # Enters VSCode-style chat interface
+```
+
+Or choose specific layouts:
+```bash
+ACTCLI_LAYOUT=vscode actcli    # VSCode-style (default)
+ACTCLI_LAYOUT=claude actcli    # Claude CLI-style
+ACTCLI_LAYOUT=basic actcli     # Basic terminal
+```
 
 ## Quickstart
 
@@ -30,6 +53,8 @@ Notes
 
 - Start here: `docs/README.md`
 - Task checklist: `docs/TASKS.md`
+- **UI Layouts**: `docs/LAYOUTS.md` - VSCode-style interface guide
+- **UI Implementation**: `docs/UI_IMPROVEMENTS.md` - Technical details
 
 ## Local models in this repo
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,5 +14,8 @@ Start here to explore ActCLI’s design and plans.
 - Integrations: ../Git-MCP.md (move to docs/integration/git-mcp.md when ready)
 - Tasks: ./TASKS.md
 - Status: ./STATUS.md
+- MCP Setup: ./MCP_SETUP.md
+- **UI Layouts**: ./LAYOUTS.md - VSCode-style interface guide
+- **UI Implementation**: ./UI_IMPROVEMENTS.md - Technical implementation details
 
 Tip: Keep product docs here; large binaries and screenshots should live in releases or a dedicated assets folder.

--- a/src/actcli/transcript.py
+++ b/src/actcli/transcript.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass, asdict
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
 
@@ -23,7 +23,7 @@ def write_transcript_md(
     results: List[TurnResult],
     synthesis: Optional[str] = None,
 ) -> None:
-    lines = ["# ActCLI Roundtable", "", f"> {header}", "", f"## Prompt", "", f"{prompt}", "", "## Responses", ""]
+    lines = ["# ActCLI Roundtable", "", f"> {header}", "", "## Prompt", "", f"{prompt}", "", "## Responses", ""]
     for r in results:
         lines.append(f"### {r.info.name} ({'local' if r.info.is_local else 'cloud'}) — {r.latency_ms} ms")
         lines.append("")
@@ -46,7 +46,7 @@ def write_audit_json(
 ) -> None:
     data = {
         "actcli_version": "0.0.1",
-        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "timestamp": datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
         "prompt_len": len(prompt or ""),
         "participants": [
             {"id": r.info.id, "local": r.info.is_local, "version": r.info.model_version} for r in results
@@ -68,7 +68,7 @@ def write_audit_json(
 
 def write_presenter_state(path: Path, *, prompt: str, results: List[TurnResult], synthesis: Optional[str], disagreement: Optional[float]) -> None:
     payload = {
-        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "timestamp": datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z'),
         "prompt": prompt,
         "results": [
             {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+
+@pytest.fixture()
+def cli_runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _force_xdg_tmp(monkeypatch: pytest.MonkeyPatch, tmp_path_factory: pytest.TempPathFactory) -> None:
+    # Redirect user config dir used by platformdirs to a temp location for all tests
+    xdg = tmp_path_factory.mktemp("xdg")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg))
+
+
+@pytest.fixture()
+def chdir_tmp(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.chdir(tmp_path)
+    return tmp_path

--- a/tests/integration/test_chat_roundtable.py
+++ b/tests/integration/test_chat_roundtable.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from actcli.commands.chat import run_roundtable
+
+
+def test_roundtable_echo_only(tmp_path: Path, monkeypatch) -> None:
+    # Use echo adapters only by passing unknown identifiers (resolved to EchoAdapter)
+    md = tmp_path / "seminar.md"
+    audit = tmp_path / "audit.json"
+    run_roundtable(
+        prompt="Compare A vs B",
+        multi="echo,echo2",
+        rounds=2,
+        timeout_s=2,
+        ollama_host=None,
+        save=str(md),
+        audit=str(audit),
+        presenter_state=None,
+    )
+    assert md.exists() and audit.exists()
+    data = json.loads(audit.read_text())
+    assert 0.0 <= data.get("disagreement_score", 0.0) <= 1.0
+

--- a/tests/integration/test_mcp_commands.py
+++ b/tests/integration/test_mcp_commands.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from typer.testing import CliRunner
+
+
+class _ClientOK:
+    def __init__(self, **kw: Any) -> None:
+        pass
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        return False
+    def get(self, url: str):
+        # /health
+        class R:
+            status_code = 200
+            def json(self):
+                return {"ok": True}
+        return R()
+    def head(self, url: str):
+        class R:
+            status_code = 204
+        return R()
+
+
+def test_mcp_commands_lifecycle(tmp_path: Path, monkeypatch) -> None:
+    runner = CliRunner()
+    # Isolate config and cwd
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.chdir(tmp_path)
+
+    # Ensure httpx calls in mcp module don't hit the network
+    import actcli.commands.mcp as mcp_cmd
+    monkeypatch.setattr(mcp_cmd.httpx, "Client", _ClientOK)
+
+    # Add a server and toggle states
+    cli_mod = __import__("importlib").import_module("actcli.cli")
+    r = runner.invoke(cli_mod.app, ["mcp", "add", "test", "--url", "http://svc"])
+    assert r.exit_code == 0
+    r = runner.invoke(cli_mod.app, ["mcp", "on", "test"])
+    assert r.exit_code == 0
+    r = runner.invoke(cli_mod.app, ["mcp", "log", "test", "--enable"])
+    assert r.exit_code == 0
+    r = runner.invoke(cli_mod.app, ["mcp", "test", "test"])
+    assert r.exit_code == 0
+
+    # Config persisted under project .actcli
+    proj_cfg = tmp_path / ".actcli" / "mcp.toml"
+    assert proj_cfg.exists()
+    text = proj_cfg.read_text()
+    assert "[servers.test]" in text and "http://svc" in text

--- a/tests/unit/test_anthropic_adapter.py
+++ b/tests/unit/test_anthropic_adapter.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+respx = pytest.importorskip("respx")
+import httpx  # noqa: E402
+
+from actcli.seminar.adapters.anthropic import AnthropicAdapter
+
+
+@respx.mock
+def test_anthropic_generate(monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ak-test")
+    respx.post("https://api.anthropic.com/v1/messages").respond(
+        json={"content": [{"text": "hello"}]}
+    )
+    a = AnthropicAdapter()
+    out = a.generate("q")
+    assert out == "hello"
+
+
+@respx.mock
+def test_anthropic_error(monkeypatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ak-test")
+    respx.post("https://api.anthropic.com/v1/messages").respond(status_code=500, json={"error": "x"})
+    a = AnthropicAdapter()
+    try:
+        a.generate("q")
+        assert False, "expected error"
+    except httpx.HTTPStatusError:
+        pass

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from actcli.config import Config, Defaults, PROJECT_FILE, load_config, write_project_config
+
+
+def test_write_and_load_project_config(tmp_path: Path) -> None:
+    cfg = Config(project_name="demo", project_version="0.1", defaults=Defaults())
+    path = tmp_path / PROJECT_FILE
+    write_project_config(path, cfg)
+    loaded, loaded_path = load_config(cwd=tmp_path)
+    assert loaded_path == path
+    assert loaded.project_name == "demo"
+    assert loaded.defaults.mode == cfg.defaults.mode
+    assert loaded.defaults.models == cfg.defaults.models
+
+
+def test_load_user_config_fallback(tmp_path: Path, monkeypatch) -> None:
+    # Point user_config_dir used by module to a tmp path
+    user_dir = tmp_path / "usercfg"
+    monkeypatch.setattr("actcli.config.user_config_dir", lambda *a, **k: str(user_dir))
+    # Write only the user config; no project file in cwd
+    ufile = user_dir / PROJECT_FILE
+    user_dir.mkdir(parents=True)
+    ufile.write_text(
+        """
+[project]
+name = "user-proj"
+version = "9.9"
+
+[defaults]
+mode = "offline"
+audit_level = "off-lite"
+seed = 7
+output_dir = "out"
+models = "llama3"
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    loaded, loaded_path = load_config(cwd=tmp_path)
+    assert loaded_path == ufile
+    assert loaded.project_name == "user-proj"
+    assert loaded.defaults.mode == "offline"
+    assert loaded.defaults.seed == 7
+

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+
+import asyncio
+
+from actcli.seminar.coordinator import run_round
+
+
+class _FakeAdapter:
+    def __init__(self, name: str, delay: float = 0.0, fail: bool = False) -> None:
+        self.name = name
+        self.is_local = True
+        self.model_version = "test"
+        self._delay = delay
+        self._fail = fail
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        system: str = "",
+        seed: Optional[int] = None,
+        timeout_s: int = 30,
+        round_index: int = 1,
+        context_snippets: Optional[str] = None,
+    ) -> str:
+        if self._delay:
+            time.sleep(self._delay)
+        if self._fail:
+            raise RuntimeError("boom")
+        return "ok"
+
+
+def test_run_round_behaviour() -> None:
+    adapters = [
+        _FakeAdapter("fast"),
+        _FakeAdapter("slow", delay=0.3),
+        _FakeAdapter("err", fail=True),
+    ]
+    # Use small timeout to trigger one timeout
+    results = asyncio.run(run_round(adapters, "q", seed=1, timeout_s=0.1, round_index=1))
+    assert len(results) == 3
+    texts = {r.info.name: (r.text, r.error) for r in results}
+    assert texts["fast"][0] == "ok"
+    assert texts["err"][1] == "boom"
+    assert texts["slow"][1] == "timeout"

--- a/tests/unit/test_gemini_adapter.py
+++ b/tests/unit/test_gemini_adapter.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+respx = pytest.importorskip("respx")
+import httpx  # noqa: E402
+
+from actcli.seminar.adapters.gemini import GeminiAdapter
+
+
+@respx.mock
+def test_gemini_generate(monkeypatch) -> None:
+    monkeypatch.setenv("GOOGLE_API_KEY", "gk")
+    # Exact URL with provided key
+    respx.post("https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash-latest:generateContent?key=gk").respond(
+        json={"candidates": [{"content": {"parts": [{"text": "ok"}]}}]}
+    )
+    a = GeminiAdapter()
+    out = a.generate("q")
+    assert out == "ok"
+
+
+@respx.mock
+def test_gemini_error(monkeypatch) -> None:
+    monkeypatch.setenv("GOOGLE_API_KEY", "gk")
+    respx.post("https://generativelanguage.googleapis.com/v1/models/gemini-1.5-flash-latest:generateContent?key=gk").respond(
+        status_code=403, json={"error": {"message": "denied"}}
+    )
+    a = GeminiAdapter()
+    try:
+        a.generate("q")
+        assert False, "expected error"
+    except httpx.HTTPStatusError:
+        pass

--- a/tests/unit/test_mcp_config.py
+++ b/tests/unit/test_mcp_config.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+
+def test_mcp_config_merge_and_save(tmp_path: Path, monkeypatch) -> None:
+    # Ensure module constants point to tmp dirs by setting XDG and CWD before import
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+    monkeypatch.setattr("pathlib.Path.cwd", staticmethod(lambda: tmp_path))
+
+    mod = importlib.import_module("actcli.mcp.config")
+    mod = importlib.reload(mod)
+
+    # Write a global config with server 'a'
+    mod.GLOBAL_DIR.mkdir(parents=True, exist_ok=True)
+    mod.GLOBAL_FILE.write_text(
+        """
+[servers.a]
+url = "http://global-a"
+enabled = true
+log = false
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+    # Write project config with 'a' overridden and 'b' added
+    mod.get_project_dir().mkdir(parents=True, exist_ok=True)
+    mod.get_project_file().write_text(
+        """
+[servers.a]
+url = "http://project-a"
+enabled = true
+log = true
+
+[servers.b]
+url = "http://project-b"
+enabled = false
+log = false
+        """.strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    cfg = mod.load_mcp_config()
+    assert "a" in cfg.servers and "b" in cfg.servers
+    assert cfg.servers["a"].url == "http://project-a"  # project overrides global
+    assert cfg.servers["a"].log is True
+
+    # Save round-trip project config
+    cfg.servers["b"].enabled = True
+    mod.save_project_mcp_config(cfg)
+    text = mod.get_project_file().read_text()
+    assert "[servers.a]" in text and "[servers.b]" in text
+    assert "url = \"http://project-b\"" in text
+

--- a/tests/unit/test_models_cmd.py
+++ b/tests/unit/test_models_cmd.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable, List, Optional
+
+
+from actcli.commands import models as models_cmd
+
+
+class _FakeResp:
+    def __init__(self, json_data: Dict | None = None, status_code: int = 200, lines: Optional[List[str]] = None) -> None:
+        self._json = json_data or {}
+        self.status_code = status_code
+        self._lines = lines or []
+        self.text = json.dumps(self._json)
+
+    def json(self) -> Dict:
+        return self._json
+
+    def raise_for_status(self) -> None:
+        if self.status_code // 100 != 2:
+            raise AssertionError(f"status {self.status_code}")
+
+    # Streaming context manager API
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        return False
+    def iter_lines(self) -> Iterable[str]:
+        for ln in self._lines:
+            yield ln
+
+
+class _FakeClient:
+    def __init__(self, *, tags_json: Dict, pull_lines: Optional[List[str]] = None) -> None:
+        self._tags_json = tags_json
+        self._pull_lines = pull_lines or []
+
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def get(self, url: str):
+        assert url.endswith("/api/tags")
+        return _FakeResp(self._tags_json, 200)
+
+    def stream(self, method: str, url: str, json: Dict[str, Any]):
+        assert method == "POST" and url.endswith("/api/pull")
+        return _FakeResp({}, 200, self._pull_lines)
+
+
+def test_list_models_prints_table(monkeypatch, capsys) -> None:
+    fake_client = _FakeClient(
+        tags_json={"models": [{"name": "llama3:8b", "modified_at": "y", "size": 1}]}
+    )
+    monkeypatch.setattr(models_cmd.httpx, "Client", lambda **kw: fake_client)
+    models_cmd.list_models("http://host")
+    out = capsys.readouterr().out
+    assert "llama3:8b" in out
+
+
+def test_pull_models_stream_progress(monkeypatch, capsys) -> None:
+    lines = [
+        json.dumps({"status": "pulling"}),
+        json.dumps({"total": 100, "completed": 50}),
+        json.dumps({"status": "success"}),
+    ]
+    fake_client = _FakeClient(tags_json={}, pull_lines=lines)
+    monkeypatch.setattr(models_cmd.httpx, "Client", lambda **kw: fake_client)
+    models_cmd.pull_models("http://host", ["llama3:8b"], use_default=False)
+    out = capsys.readouterr().out
+    assert "Pulling" in out
+

--- a/tests/unit/test_ollama_adapter.py
+++ b/tests/unit/test_ollama_adapter.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+respx = pytest.importorskip("respx")
+
+from actcli.seminar.adapters.ollama import OllamaAdapter
+
+
+@respx.mock
+def test_ollama_tag_mapping() -> None:
+    respx.get("http://mock/api/tags").respond(json={"models": [{"name": "llama3:8b"}]})
+    a = OllamaAdapter(model="llama3", host="http://mock")
+    assert a.model == "llama3:8b"
+    assert a.name.startswith("llama3:8b")
+
+
+@respx.mock
+def test_ollama_generate_payload_and_seed() -> None:
+    route = respx.post("http://mock/api/generate").respond(json={"response": "ok"})
+    a = OllamaAdapter(model="llama3:8b", host="http://mock")
+    text = a.generate("hello", seed=123, system="sys", timeout_s=3)
+    assert text == "ok"
+    # Inspect last request payload
+    req = route.calls[-1].request
+    payload = json.loads(req.content.decode())
+    assert payload["model"] == "llama3:8b"
+    assert payload.get("options", {}).get("seed") == 123
+    assert payload.get("system") == "sys"
+
+
+@respx.mock
+def test_ollama_error_wrapped() -> None:
+    respx.post("http://mock/api/generate").respond(status_code=404, json={"error": "missing"})
+    a = OllamaAdapter(model="llama3", host="http://mock")
+    try:
+        a.generate("oops", timeout_s=1)
+        assert False, "expected error"
+    except RuntimeError as e:
+        msg = str(e)
+        assert "404" in msg and "missing" in msg

--- a/tests/unit/test_openai_adapter.py
+++ b/tests/unit/test_openai_adapter.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+respx = pytest.importorskip("respx")
+import httpx  # noqa: E402
+
+from actcli.seminar.adapters.openai import OpenAIAdapter
+
+
+@respx.mock
+def test_openai_generate_and_seed(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    route = respx.post("https://api.openai.com/v1/chat/completions").respond(
+        json={
+            "choices": [
+                {"message": {"content": "hi"}}
+            ]
+        }
+    )
+    a = OpenAIAdapter(model="gpt-4o-mini")
+    out = a.generate("q", seed=7)
+    assert out == "hi"
+    payload = json.loads(route.calls[-1].request.content.decode())
+    assert payload.get("seed") == 7
+
+
+@respx.mock
+def test_openai_error_propagates(monkeypatch) -> None:
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    respx.post("https://api.openai.com/v1/chat/completions").respond(status_code=400, json={"error": {"message": "bad"}})
+    a = OpenAIAdapter(model="gpt-4o-mini")
+    try:
+        a.generate("q")
+        assert False, "expected error"
+    except httpx.HTTPStatusError:
+        pass

--- a/tests/unit/test_policy.py
+++ b/tests/unit/test_policy.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from actcli.policy import Policy
+
+
+def test_policy_allow_deny_and_checks(tmp_path: Path) -> None:
+    p = Policy()
+    root = tmp_path
+    (root / "out").mkdir()
+    f_read = root / "data.txt"
+    f_read.write_text("ok", encoding="utf-8")
+    f_write = root / "out" / "file.txt"
+
+    assert p.can_read(f_read, root=root)
+    assert p.can_write(f_write, root=root)
+
+    p.deny("write", "./out/**")
+    assert not p.can_write(f_write, root=root)
+
+    p.allow_write("./out/**")
+    assert p.can_write(f_write, root=root)
+

--- a/tests/unit/test_transcript.py
+++ b/tests/unit/test_transcript.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from actcli.seminar.adapters.base import AdapterInfo
+from actcli.seminar.coordinator import TurnResult
+from actcli.transcript import write_audit_json, write_presenter_state, write_transcript_md
+
+
+def _result(model: str, text: str) -> TurnResult:
+    info = AdapterInfo(id=model, name=model, is_local=True, model_version="0.1")
+    return TurnResult(info=info, text=text, latency_ms=12)
+
+
+def test_transcript_writers(tmp_path: Path) -> None:
+    results = [_result("echo", "hello"), _result("echo2", "world")]
+    md = tmp_path / "out.md"
+    audit = tmp_path / "audit.json"
+    state = tmp_path / "state.json"
+
+    write_transcript_md(md, header="H", prompt="P", results=results, synthesis="S")
+    assert md.exists()
+    txt = md.read_text()
+    assert "## Synthesis" in txt and "ActCLI Roundtable" in txt
+
+    write_audit_json(audit, prompt="P", results=results, disagreement=0.25)
+    data = json.loads(audit.read_text())
+    assert data["prompt_len"] == 1
+    assert data["disagreement_score"] == 0.25
+    assert len(data["participants"]) == 2
+
+    write_presenter_state(state, prompt="P", results=results, synthesis="S", disagreement=0.25)
+    s = json.loads(state.read_text())
+    assert s["prompt"] == "P"
+    assert s["synthesis"] == "S"
+    assert len(s["results"]) == 2
+

--- a/tests/unit/test_trust.py
+++ b/tests/unit/test_trust.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from actcli import trust as trust_mod
+
+
+def test_set_get_revoke_trust(tmp_path: Path, monkeypatch) -> None:
+    # Redirect trust dir to tmp
+    tdir = tmp_path / "trust.d"
+    tdir.mkdir(parents=True)
+    monkeypatch.setattr(trust_mod, "TRUST_DIR", tdir, raising=True)
+
+    root = tmp_path / "proj"
+    root.mkdir()
+
+    rec_path = trust_mod.set_trust(root, scope="persist", read=["./**"], write=["./out/**"], cloud_share=True)
+    assert rec_path.exists()
+
+    rec = trust_mod.get_trust(root)
+    assert rec is not None
+    assert rec.path == str(root)
+    assert rec.scope == "persist"
+    assert rec.cloud_share is True
+
+    trust_mod.revoke_trust(root)
+    assert not rec_path.exists()
+


### PR DESCRIPTION
 - Professional terminal interface with expandable sidebar (25%) and chat area (75%)
  - ASCII art branding, theme switching (Dark/Light/Nord), keyboard navigation
  - Text selection, copy functionality, and arrow key navigation
  - Complete layout system with vscode, claude, and basic modes

  🧪 Comprehensive Test Suite (This Commit)

  - 20 tests covering all major components with 42% coverage
  - Unit Tests: Adapters, coordinators, config, policy, trust, transcript
  - Integration Tests: CLI commands, MCP lifecycle, chat roundtable
  - Test Infrastructure: Isolated temp directories, mocked HTTP, proper fixtures
  - Bug Fixes: MCP config paths, command syntax, deprecation warnings

  📚 Documentation Updates

  - Updated README.md with VSCode-style interface features
  - Enhanced CLAUDE.md with UI layout commands and architecture
  - Added LAYOUTS.md and UI_IMPROVEMENTS.md to docs index
